### PR TITLE
Added New Annealing Solver Type for Discrete Optimization Problems: `sa_disc_type`

### DIFF
--- a/examples/continuous_test/Makefile
+++ b/examples/continuous_test/Makefile
@@ -20,7 +20,7 @@ SIMANN := ../../src
 
 #-----------------------------------------------------------------------------------
 #Add source files as necessary
-#If the files are not comiled using the genieric rules, add commands under their
+#If the files are not comiled using the generic rules, add commands under their
 #rule declaration. Add these items to FILTER
 #-----------------------------------------------------------------------------------
 

--- a/examples/ising/Makefile
+++ b/examples/ising/Makefile
@@ -1,0 +1,98 @@
+# Defining variables
+FC:=gfortran
+EXE:=ising
+EXT:=.exe
+
+all:			TYPE :=
+debug:    TYPE := _Debug
+catch:    TYPE := _Catch
+coverage: TYPE := _Coverage
+
+all:      OPT := -O3 -Wall -Werror
+debug:    OPT := -O0 -g -fbacktrace -ffpe-trap=zero,overflow,underflow -Wall -Werror
+catch:    OPT := -O0 -g -Wall -W -Wsurprising -Werror
+coverage: OPT := -O0 -g --coverage -Wall -Werror
+
+#-----------------------------------------------------------------------------------
+#Directory Paths
+#-----------------------------------------------------------------------------------
+SIMANN := ../../src
+
+#-----------------------------------------------------------------------------------
+#Add source files as necessary
+#If the files are not comiled using the generic rules, add commands under their
+#rule declaration. Add these items to FILTER
+#-----------------------------------------------------------------------------------
+
+SRC := ising.f90
+
+OBJ := $(SRC:.f90=.o)
+MOD := $(OBJ:.o=.mod)
+
+FILTER := \
+
+OBJ_FILTER := $(FILTER:.f90=.o)
+MOD_FILTER := $(FILTER:.f90=.mod)
+
+#-----------------------------------------------------------------------------------
+#Add simple compile SIMANN files
+#-----------------------------------------------------------------------------------
+SIMANN_SRC := $(SIMANN)/OpenFSAM.f90
+
+SIMANN_OBJ := $(patsubst %.f90,%.o,$(notdir $(SIMANN_SRC)))
+
+SIMANN_MOD := $(SIMANN_OBJ:.o=.mod)
+
+#-----------------------------------------------------------------------------------
+#Phony targets for cleaning and building
+#-----------------------------------------------------------------------------------
+.PHONY: all debug catch coverage clean reset
+
+print-%  : ; @echo $* = $($*)
+
+all: $(EXE)
+
+debug: $(EXE)
+
+catch: $(EXE)
+
+coverage: $(EXE)
+
+#Intended to clean up compilation artifacts but leave executable & coverage
+clean:
+	rm -f $(OBJ) $(SIMANN_OBJ) $(LIB_OBJ)
+	rm -f $(MOD) $(SIMANN_MOD) $(LIB_MOD)
+	rm -f $(COMP_DEP)
+
+#Intended to reset directory to fresh state with no exe or artifacts
+reset: clean
+	rm -f *.gcno *.gcda *.o *.mod
+	rm -f -r $(EXE)*.dSYM
+	rm -f *.exe
+
+#-----------------------------------------------------------------------------------
+#Generics for source files
+#-----------------------------------------------------------------------------------
+$(filter-out $(OBJ_FILTER), $(OBJ)): %.o:	%.f90
+	$(FC) -c $(OPT) $<
+
+$(filter-out $(MOD_FILTER), $(MOD)):	%.mod:	%.f90
+	$(FC) -c $(OPT) $<
+
+$(EXE): $(OBJ) $(SIMANN_OBJ) $(LIB_OBJ)
+	$(FC) -o $@$(TYPE)$(EXT) $(OPT) $(OBJ) $(SIMANN_OBJ) $(LIB_OBJ)
+
+#-----------------------------------------------------------------------------------
+#Generics for contrib files
+#-----------------------------------------------------------------------------------
+$(SIMANN_OBJ): %.o: $(filter %.f90, $(SIMANN_SRC))
+	$(FC) -c $(OPT) $^
+$(SIMANN_MOD):	%.mod:	$(filter %.f90, $(SIMANN_SRC))
+	$(FC) -c $(OPT) $^
+
+#-----------------------------------------------------------------------------------
+#Dependency List
+#Use [gfortran -M -cpp *.f90] repeatedly until clean compile to update rules below
+#may need to make first to get OpenFSAM module
+#-----------------------------------------------------------------------------------
+ising.o: ising.f90 OpenFSAM.mod

--- a/examples/ising/ising.f90
+++ b/examples/ising/ising.f90
@@ -1,0 +1,82 @@
+program isingmodel
+    use :: OpenFSAM, only : sa_disc_type
+    implicit none
+
+    type(sa_disc_type) :: annealer
+    integer :: n_spins
+    real(8) :: energy_initial
+    real(8), dimension(:), allocatable :: h
+    real(8), dimension(:,:), allocatable :: j
+    integer, dimension(:), allocatable :: state
+
+    n_spins = 1000
+    allocate(j(n_spins,n_spins))
+    allocate(h(n_spins))
+    allocate(state(n_spins))
+
+    call initialize_ising(n_spins, j, h, state)
+
+    !> Initialize Annealer
+    annealer%max_step = 100
+    annealer%alpha = 0.01
+    annealer%t_max = 100.0
+    annealer%t_min = 0.0
+    annealer%cool_opt = "QuadAdd"
+    annealer%mon_cool = .true.
+    annealer%prog_bar = .true.
+    annealer%resvar = 0.0
+    annealer%energy => ising_hamiltonian
+    annealer%var_values = [1, -1]
+    annealer%num_perturb = 10
+    allocate(annealer%state_curr(n_spins))
+    annealer%state_curr = state
+
+    energy_initial = ising_hamiltonian(annealer, annealer%state_curr)
+
+    write(*, '(A)')'----------------------------------------------------------------------------------'
+    write(*, '(A)')'                    finding ising model ground state'
+    write(*, '(A)')'----------------------------------------------------------------------------------'
+
+    !> Find Ising Model's Ground State
+    call annealer%optimize()
+
+    write(*, '(A)', advance="no") "Random Initial Energy: "
+    write(*, '(F0.2)')  energy_initial
+    write(*, '(A)', advance="no") "Ground State Energy: "
+    write(*, '(F0.2)')  annealer%e_best
+
+    contains
+
+        subroutine initialize_ising(n_spins, j, h, state)
+            integer, intent(in) :: n_spins
+            real(8), dimension(n_spins:n_spins), intent(inout) :: j
+            real(8), dimension(n_spins), intent(inout) :: h
+            integer, dimension(n_spins), intent(inout) :: state
+            real(8), dimension(n_spins) :: temp_r
+
+            call random_number(j)
+            j = 2 * j - 0.5
+
+            call random_number(h)
+            h = 2 * h - 0.5
+
+            call random_number(temp_r)
+            state = merge(1, -1, (temp_r - 0.5) >= 0)
+        end subroutine initialize_ising
+
+        !> Ising Model Hamiltonian (with Magnetic Moment, mu = 1)
+        function ising_hamiltonian(sa, state)
+            class(sa_disc_type), intent(inout) :: sa
+            integer, dimension(:), intent(in) :: state
+            integer, dimension(:,:), allocatable :: state_mat
+            real(8) :: ising_hamiltonian, r
+
+            !this line is literally just to ensure that it doesn't complain about not using the variables
+            if(.FALSE.)r=sa%e_best
+
+            state_mat = reshape(spread(state, 2, size(state)), [size(state), size(state)])
+            ising_hamiltonian = -1 * sum(j * state_mat * transpose(state_mat)) - dot_product(h, state)
+
+        end function ising_hamiltonian
+
+end program isingmodel

--- a/examples/sa_ts_sa/Makefile
+++ b/examples/sa_ts_sa/Makefile
@@ -20,7 +20,7 @@ SIMANN := ../../src
 
 #-----------------------------------------------------------------------------------
 #Add source files as necessary
-#If the files are not comiled using the genieric rules, add commands under their
+#If the files are not comiled using the generic rules, add commands under their
 #rule declaration. Add these items to FILTER
 #-----------------------------------------------------------------------------------
 

--- a/examples/traveling_sales_general/Makefile
+++ b/examples/traveling_sales_general/Makefile
@@ -20,7 +20,7 @@ SIMANN := ../../src
 
 #-----------------------------------------------------------------------------------
 #Add source files as necessary
-#If the files are not comiled using the genieric rules, add commands under their
+#If the files are not comiled using the generic rules, add commands under their
 #rule declaration. Add these items to FILTER
 #-----------------------------------------------------------------------------------
 

--- a/src/OpenFSAM.f90
+++ b/src/OpenFSAM.f90
@@ -458,6 +458,7 @@ CONTAINS
     num_perturb=MAX(1,thisSA%num_perturb)
 
     i=1
+    get_neigh_disc=thisSA%state_curr
     DO WHILE(i .LE. num_perturb)
       i=i+1
       !pick parameter to perturb

--- a/src/OpenFSAM.f90
+++ b/src/OpenFSAM.f90
@@ -5,7 +5,7 @@
 MODULE OpenFSAM
   IMPLICIT NONE
   PRIVATE
-  PUBLIC sa_comb_type,sa_cont_type
+  PUBLIC sa_comb_type,sa_cont_type,sa_disc_type
 
   REAL(8),PARAMETER :: pi=4.D0*ATAN(1.D0)
 
@@ -448,7 +448,7 @@ CONTAINS
     INTEGER,DIMENSION(SIZE(s_curr)) :: get_neigh_disc
 
     REAL(8) :: temp_r
-    INTEGER :: i,temp_i,j,val,num_perturb
+    INTEGER :: i,j,val,num_perturb
     REAL(8), DIMENSION(SIZE(thisSA%var_values)) :: rand
 
     !this line is literally just to ensure that it doesn't complain about not using the variables
@@ -459,6 +459,7 @@ CONTAINS
 
     i=1
     DO WHILE(i .LE. num_perturb)
+      i=i+1
       !pick parameter to perturb
       CALL random_number(temp_r)
       j=1+FLOOR(SIZE(s_curr)*temp_r)


### PR DESCRIPTION
The existing OpenFSAM is very powerful and can solve many different kinds of optimization problems, but one class of problems seems to have been left out: discrete optimization problems! (Finding the ground state of the Ising model, the Quadratic Unconstrained Binary Optimization problem, MAX-2-SAT, etc.) To address this, I've written a new annealing type called `sa_disc_type` to be used for such problems.

The `sa_disc_type` extends `sa_type_base` and adds a few important object properties:

- `var_values`: An array that allows the end user to specify the domain for their discrete objective function
- `num_perturb`: Borrowed from the `sa_cont_type`, it specifies the number of parameters to perturb when seeking a new neighbouring state. Defaults to only changing one parameter at a time.

The new function `get_neigh_disc` finds a new neighbouring state by perturbing `num_perturb` parameters of the energy function. (It is flexible enough to allow for any number of possible domain values, not just functions with binary parameters.)

To complement this additional type, I've added an example that initializes and optimizes the Ising model.

The README has also been updated to accommodate the new type.

### Side Note

Note that the `sa_comb_type` can _technically_ be used to solve these discrete optimization problems, but the implementation is rather ugly. It requires setting an initial state which contains as many values as there are distinct values in the domain. (In the case of a problem with _n_ binary parameters, this means _2n_ values.) Then, in the energy function, only the first _n_ values must be used when calculating the performance of the given state. This technique comes with the additional downside that only one parameter can be perturbed in each iteration.